### PR TITLE
handle review apps

### DIFF
--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -13,7 +13,7 @@ function getEnvVariable(name) {
 
 const upload = () => {
   try {
-    if (getEnvVariable('IS_REVIEW_APP')) {
+    if (process.env.IS_REIVEW_APP) {
       throw 'Review app detected'
     }
   } catch (error) {

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -15,7 +15,9 @@ const upload = () => {
   try {
     console.log("detecting review app")
     // console.log('process.env', Object.keys(process.env))
-    console.log(fs.readFileSync(process.env.ENV_DIR))
+    fs.readdirSync(process.env.ENV_DIR).forEach(file => {
+      console.log(file);
+    });
     if (process.env.IS_REVIEW_APP) {
       console.log("Review app detected")
       throw 'Review app detected'

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -14,7 +14,7 @@ function getEnvVariable(name) {
 const upload = () => {
   try {
     console.log("detecting review app")
-    console.log('process.env', process.env.IS_REVIEW_APP)
+    console.log('process.env', Object.keys(process.env))
     if (process.env.IS_REVIEW_APP) {
       console.log("Review app detected")
       throw 'Review app detected'

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -14,8 +14,7 @@ function getEnvVariable(name) {
 const upload = () => {
   try {
     if (fs.readdirSync(process.env.ENV_DIR).includes("IS_REVIEW_APP")) {
-      console.log("Review app detected")
-      throw new Error('Review app detected')
+      throw 'Review app detected'
     }
   } catch (error) {
     console.error('Static Uploader is not configured for this deploy');

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -13,6 +13,8 @@ function getEnvVariable(name) {
 
 const upload = () => {
   try {
+    console.log("detecting review app")
+    console.log('process.env', process.env.IS_REVIEW_APP)
     if (process.env.IS_REVIEW_APP) {
       console.log("Review app detected")
       throw 'Review app detected'

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -42,9 +42,9 @@ const upload = () => {
       console.error(">>> cred", cred)
   })
   } catch(error) {
-    console.error('Static Uploader is not configured for this deploy');
+    console.error('Not all AWS config vars found');
     console.error(error);
-    console.error('Exiting without error');
+    console.error('Exiting');
     process.exit(1);
   }
 
@@ -102,7 +102,7 @@ const upload = () => {
           if (error) {
             console.error('Static Uploader failed to upload to S3');
             console.error(error);
-            console.error('Exiting without error');
+            console.error('Exiting');
             process.exit(1);
           }
 

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -13,8 +13,8 @@ function getEnvVariable(name) {
 
 const upload = () => {
   try {
-    if (process.env.IS_REVIEW_APP) {
-      throw "Review app detected"
+    if (getEnvVariable('IS_REVIEW_APP')) {
+      throw 'Review app detected'
     }
   } catch (error) {
     console.error('Static Uploader is not configured for this deploy');

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -14,7 +14,8 @@ function getEnvVariable(name) {
 const upload = () => {
   try {
     console.log("detecting review app")
-    console.log('process.env', Object.keys(process.env))
+    // console.log('process.env', Object.keys(process.env))
+    console.log(fs.readFileSync(process.env.ENV_DIR))
     if (process.env.IS_REVIEW_APP) {
       console.log("Review app detected")
       throw 'Review app detected'

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -13,14 +13,9 @@ function getEnvVariable(name) {
 
 const upload = () => {
   try {
-    console.log("detecting review app")
-    // console.log('process.env', Object.keys(process.env))
-    fs.readdirSync(process.env.ENV_DIR).forEach(file => {
-      console.log(file);
-    });
-    if (process.env.IS_REVIEW_APP) {
+    if (fs.readdirSync(process.env.ENV_DIR).includes("IS_REVIEW_APP")) {
       console.log("Review app detected")
-      throw 'Review app detected'
+      throw new Error('Review app detected')
     }
   } catch (error) {
     console.error('Static Uploader is not configured for this deploy');

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -13,7 +13,7 @@ function getEnvVariable(name) {
 
 const upload = () => {
   try {
-    if (getEnvVariable("IS_REVIEW_APP")) {
+    if (process.env.IS_REVIEW_APP) {
       throw new Error("Review app detected")
     }
     // AWS.config.logger = process.stdout;

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -13,7 +13,9 @@ function getEnvVariable(name) {
 
 const upload = () => {
   try {
-
+    if (getEnvVariable("IS_REVIEW_APP")) {
+      throw new Error("Review app detected")
+    }
     // AWS.config.logger = process.stdout;
     AWS.config.maxRetries = 10;
 

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -37,7 +37,7 @@ const upload = () => {
     console.error('Static Uploader is not configured for this deploy');
     console.error(error);
     console.error('Exiting without error');
-    process.exit(1);
+    process.exit(0);
   }
 
   // the sha-1 or version supplied by heroku used to version builds in the path
@@ -95,7 +95,7 @@ const upload = () => {
             console.error('Static Uploader failed to upload to S3');
             console.error(error);
             console.error('Exiting without error');
-            process.exit(1);
+            process.exit(0);
           }
 
           var profiled = process.env.BUILD_DIR + '/.profile.d';

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -37,7 +37,7 @@ const upload = () => {
     console.error('Static Uploader is not configured for this deploy');
     console.error(error);
     console.error('Exiting without error');
-    process.exit(0);
+    process.exit(1);
   }
 
   // the sha-1 or version supplied by heroku used to version builds in the path
@@ -95,7 +95,7 @@ const upload = () => {
             console.error('Static Uploader failed to upload to S3');
             console.error(error);
             console.error('Exiting without error');
-            process.exit(0);
+            process.exit(1);
           }
 
           var profiled = process.env.BUILD_DIR + '/.profile.d';

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -13,7 +13,7 @@ function getEnvVariable(name) {
 
 const upload = () => {
   try {
-    if (process.env.IS_REIVEW_APP) {
+    if (process.env.IS_REVIEW_APP) {
       throw 'Review app detected'
     }
   } catch (error) {

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -14,6 +14,7 @@ function getEnvVariable(name) {
 const upload = () => {
   try {
     if (process.env.IS_REVIEW_APP) {
+      console.log("Review app detected")
       throw 'Review app detected'
     }
   } catch (error) {

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -14,8 +14,16 @@ function getEnvVariable(name) {
 const upload = () => {
   try {
     if (process.env.IS_REVIEW_APP) {
-      throw new Error("Review app detected")
+      throw "Review app detected"
     }
+  } catch (error) {
+    console.error('Static Uploader is not configured for this deploy');
+    console.error(error);
+    console.error('Exiting without error');
+    process.exit(0);
+  }
+
+  try {
     // AWS.config.logger = process.stdout;
     AWS.config.maxRetries = 10;
 

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -12,15 +12,11 @@ function getEnvVariable(name) {
 }
 
 const upload = () => {
-  const isDisableAssetUploadFlag = fs.readdirSync(process.env.ENV_DIR).includes("DISABLE_ASSET_UPLOAD")
-  if (isDisableAssetUploadFlag) {
-    const shouldDisableAssetUpload = getEnvVariable("DISABLE_ASSET_UPLOAD")
-    console.log({ shouldDisableAssetUpload })
-    if (shouldDisableAssetUpload) {
-        console.error('Static Uploader is disabled for this deploy');
-        console.error('Exiting without error');
-        process.exit(0);
-     }
+  const shouldDisableAssetUpload = getEnvVariable('DISABLE_ASSET_UPLOAD') === 'true'
+  if (shouldDisableAssetUpload) {
+    console.error('Static Uploader is disabled for this deploy');
+    console.error('Exiting without error');
+    process.exit(0);
   }
 
   try {

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -19,8 +19,6 @@ const upload = () => {
     process.exit(0);
   }
 
-  const shouldDisableAssetUpload = getEnvVariable('DISABLE_ASSET_UPLOAD') === 'true'
-
   try {
     // AWS.config.logger = process.stdout;
     AWS.config.maxRetries = 10;

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -12,15 +12,15 @@ function getEnvVariable(name) {
 }
 
 const upload = () => {
-  try {
-    if (fs.readdirSync(process.env.ENV_DIR).includes("IS_REVIEW_APP")) {
-      throw 'Review app detected'
-    }
-  } catch (error) {
-    console.error('Static Uploader is not configured for this deploy');
-    console.error(error);
-    console.error('Exiting without error');
-    process.exit(0);
+  const isDisableAssetUploadFlag = fs.readdirSync(process.env.ENV_DIR).includes("DISABLE_ASSET_UPLOAD")
+  if (isDisableAssetUploadFlag) {
+    const shouldDisableAssetUpload = getEnvVar("DISABLE_ASSET_UPLOAD")
+    console.log({ shouldDisableAssetUpload })
+    if (shouldDisableAssetUpload) {
+        console.error('Static Uploader is disabled for this deploy');
+        console.error('Exiting without error');
+        process.exit(0);
+     }
   }
 
   try {

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -14,7 +14,7 @@ function getEnvVariable(name) {
 const upload = () => {
   const isDisableAssetUploadFlag = fs.readdirSync(process.env.ENV_DIR).includes("DISABLE_ASSET_UPLOAD")
   if (isDisableAssetUploadFlag) {
-    const shouldDisableAssetUpload = getEnvVar("DISABLE_ASSET_UPLOAD")
+    const shouldDisableAssetUpload = getEnvVariable("DISABLE_ASSET_UPLOAD")
     console.log({ shouldDisableAssetUpload })
     if (shouldDisableAssetUpload) {
         console.error('Static Uploader is disabled for this deploy');

--- a/lib/processStaticFiles.js
+++ b/lib/processStaticFiles.js
@@ -12,12 +12,14 @@ function getEnvVariable(name) {
 }
 
 const upload = () => {
-  const shouldDisableAssetUpload = getEnvVariable('DISABLE_ASSET_UPLOAD') === 'true'
-  if (shouldDisableAssetUpload) {
+  const isDisableAssetUploadFlag = fs.readdirSync(process.env.ENV_DIR).includes("DISABLE_ASSET_UPLOAD")
+  if (isDisableAssetUploadFlag && getEnvVariable("DISABLE_ASSET_UPLOAD") === 'true') {
     console.error('Static Uploader is disabled for this deploy');
     console.error('Exiting without error');
     process.exit(0);
   }
+
+  const shouldDisableAssetUpload = getEnvVariable('DISABLE_ASSET_UPLOAD') === 'true'
 
   try {
     // AWS.config.logger = process.stdout;

--- a/lib/tests/processStaticFilesUpload.test.js
+++ b/lib/tests/processStaticFilesUpload.test.js
@@ -1,7 +1,9 @@
 const upload = require('../processStaticFiles');
+var fs = require('fs');
 
 describe('buildpack is not properly configured', () => {
     it('build will fail with error', async () => {
+        process.env.ENV_DIR = '/';
         const mockExit = jest.spyOn(process, 'exit')
             .mockImplementation((number) => { throw new Error('process.exit: ' + number); });
         expect(() => {
@@ -10,4 +12,18 @@ describe('buildpack is not properly configured', () => {
         expect(mockExit).toHaveBeenCalledWith(1);
         mockExit.mockRestore();
       });
+})
+
+describe('review app build', () => {
+    it("exits without error", () => {
+        process.env.ENV_DIR = '/';
+        jest.spyOn(fs, 'readdirSync').mockReturnValue(["IS_REVIEW_APP"])
+        const mockExit = jest.spyOn(process, 'exit')
+                .mockImplementation((number) => { throw new Error('process.exit: ' + number); });
+        expect(() => {
+            upload();
+        }).toThrow();
+        expect(mockExit).toHaveBeenCalledWith(0);
+        mockExit.mockRestore();
+    })
 })

--- a/lib/tests/processStaticFilesUpload.test.js
+++ b/lib/tests/processStaticFilesUpload.test.js
@@ -14,7 +14,7 @@ describe('buildpack is not properly configured', () => {
       });
 })
 
-describe('review app build', () => {
+describe('DISABLE_ASSET_UPLOAD is true', () => {
     it("exits without error", () => {
         process.env.ENV_DIR = '/';
         jest.spyOn(fs, 'readdirSync').mockReturnValue(['DISABLE_ASSET_UPLOAD'])

--- a/lib/tests/processStaticFilesUpload.test.js
+++ b/lib/tests/processStaticFilesUpload.test.js
@@ -17,7 +17,8 @@ describe('buildpack is not properly configured', () => {
 describe('review app build', () => {
     it("exits without error", () => {
         process.env.ENV_DIR = '/';
-        jest.spyOn(fs, 'readdirSync').mockReturnValue(["IS_REVIEW_APP"])
+        jest.spyOn(fs, 'readdirSync').mockReturnValue(['DISABLE_ASSET_UPLOAD'])
+        jest.spyOn(fs, 'readFileSync').mockReturnValue('true')
         const mockExit = jest.spyOn(process, 'exit')
                 .mockImplementation((number) => { throw new Error('process.exit: ' + number); });
         expect(() => {


### PR DESCRIPTION
# Description

This buildpack has been causing builds of review apps in `highline` to fail. This PR resolves that issue, allowing any app with the Heroku config var `IS_REVIEW_APP` to exit the process without error.

# Note

In order for the process not to error our when the config var `IS_REVIEW_APP` does not exist, we use the `includes` method (which returns a boolean) rather than check the value of `IS_REVIEW_APP`. Hence review apps should have the config var, but staging and production apps shouldn't. This has already been implemented in [`highline`'s Heroku pipeline](https://dashboard.heroku.com/pipelines/eb3de070-e4a4-4469-995c-59b805f2e8c7/settings).